### PR TITLE
add a top-level file that can be required to load the full gem

### DIFF
--- a/lib/rspec_queue.rb
+++ b/lib/rspec_queue.rb
@@ -1,0 +1,3 @@
+require 'rspec_queue/configuration'
+require 'rspec_queue/server_runner'
+require 'rspec_queue/worker_runner'


### PR DESCRIPTION
Adds `lib/rspec_queue.rb` so it's easy for users to require the gem without understanding the internal file structure
