### PR TITLE
Add FailureListFormatter that logs parsable failures

### DIFF
--- a/bin/rspec-queue
+++ b/bin/rspec-queue
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'rspec_queue/server_runner'
 require 'rspec_queue/formatter'
+require 'rspec_queue/failure_list_formatter'
 
-ENV['SPEC_OPTS'] = "--format RSpecQueue::Formatter" unless ENV['SPEC_OPTS']
+ENV['SPEC_OPTS'] = "--format RSpecQueue::Formatter --format RSpecQueue::FailureListFormatter --out log/rspec-failures.log" unless ENV['SPEC_OPTS']
 RSpecQueue::ServerRunner.invoke

--- a/bin/rspec-queue-worker
+++ b/bin/rspec-queue-worker
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'rspec_queue/worker_runner'
 require 'rspec_queue/formatter'
+require 'rspec_queue/failure_list_formatter'
 
 RSpecQueue::WorkerRunner.invoke

--- a/lib/rspec_queue/failure_list_formatter.rb
+++ b/lib/rspec_queue/failure_list_formatter.rb
@@ -1,0 +1,19 @@
+require 'rspec/core/formatters'
+
+module RSpecQueue
+  # Taken from rspec-core 3.9.0.pre FailureListFormatter
+  class FailureListFormatter < RSpec::Core::Formatters::BaseFormatter
+    RSpec::Core::Formatters.register self, :example_failed, :dump_profile, :message
+
+    def example_failed(failure)
+      output.puts "#{failure.example.location}:#{failure.example.description}"
+    end
+
+    # Discard profile and messages
+    #
+    # These outputs are not really relevant in the context of this failure
+    # list formatter.
+    def dump_profile(_profile); end
+    def message(_message); end
+  end
+end


### PR DESCRIPTION
We'd like to keep track of intermittently failing specs, and to do that we'd like a parsable list of failing specs. Later versions of rspec contain `FailureListFormatter` that can do this, so port in a copy and add it as a default formatter, outputting to `log/rspec-failures.log`.