### PR TITLE
Make rspec-queue self testable

### DIFF
--- a/lib/rspec_queue/server.rb
+++ b/lib/rspec_queue/server.rb
@@ -1,3 +1,6 @@
+require 'socket'
+require 'securerandom'
+
 module RSpecQueue
   class Server
 

--- a/lib/rspec_queue/server_runner.rb
+++ b/lib/rspec_queue/server_runner.rb
@@ -6,13 +6,14 @@ require 'rspec_queue/worker'
 module RSpecQueue
   class ServerRunner < RSpec::Core::Runner
     def run_specs(example_groups)
+      worker_pids = []
+
       example_group_hash = example_groups.map { |example_group|
         [example_group.id, example_group]
       }.to_h
 
       # start the server, so we are ready to accept connections from workers
       server = RSpecQueue::Server.new
-      worker_pids = []
 
       RSpecQueue::Configuration.instance.worker_count.times do |i|
         env = {
@@ -38,7 +39,7 @@ module RSpecQueue
         end
       end
     ensure
-      server.close
+      server.close if server
 
       worker_pids.each do |pid|
         Process.kill("TERM", pid)

--- a/lib/rspec_queue/worker.rb
+++ b/lib/rspec_queue/worker.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'socket'
 
 module RSpecQueue
   class Worker


### PR DESCRIPTION
It should be possible for rspec-queue to run it's own tests, for example:

```
bundle exec rspec-queue spec
```

Which, with a few tweaks, is now the case.