### PR TITLE
Allow RSpec configuration suite hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0 (22 April 2020)
+- Allow RSpec configuration suite hooks
+- Requires RSpec >= 3.2
+
 # 0.2.0 (24 May 2019)
 - Write failed examples to log/rspec-failures.log
 - Made server more resilient to early problems

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A parallel test runner specifically for rspec.
 
 The main difference between this and similar gems is that it spawns entirely new worker processes instead of forking. This makes configuring the workers easier (especially when Rails is involved) as many things will "just work".
 
-It's intended to work with RSpec >= 3.0. It may work with earlier versions, but I doubt it.
+It's intended to work with RSpec >= 3.2. It may work with earlier versions, but I doubt it.
 
 ## Usage
 Put it in your Gemfile, bundle, and you're away.

--- a/lib/rspec_queue/worker_runner.rb
+++ b/lib/rspec_queue/worker_runner.rb
@@ -14,16 +14,18 @@ module RSpecQueue
 
       worker = RSpecQueue::Worker.new
 
-      reporter = @configuration.reporter
+      @configuration.with_suite_hooks do
+        reporter = @configuration.reporter
 
-      while(worker.has_work?)
-        # can we pass in a custom reporter which instantly reports back
-        # to the server?
-        example_group_hash[worker.current_example].run(reporter)
+        while(worker.has_work?)
+          # can we pass in a custom reporter which instantly reports back
+          # to the server?
+          example_group_hash[worker.current_example].run(reporter)
+        end
+
+          # report the results of the examples run to the master process
+        worker.finish(reporter)
       end
-
-        # report the results of the examples run to the master process
-      worker.finish(reporter)
 
     ensure
       Process.exit

--- a/rspec-queue.gemspec
+++ b/rspec-queue.gemspec
@@ -11,6 +11,6 @@ spec = Gem::Specification.new do |s|
   s.executables << 'rspec-queue'
   s.executables << 'rspec-queue-worker'
 
-  s.add_dependency 'rspec-core', '>= 3.0'
+  s.add_dependency 'rspec-core', '>= 3.2'
   s.add_development_dependency 'rspec'
 end

--- a/rspec-queue.gemspec
+++ b/rspec-queue.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'rspec-queue'
-  s.version = '0.2.0'
+  s.version = '0.3.0'
   s.licenses = ['MIT']
   s.summary = 'parallel rspec runner'
   s.authors = ["Nick Browne"]


### PR DESCRIPTION
**Why?**

RSpec allow using custom hooks in its suite since its [3.2 version](https://github.com/rspec/rspec-core/blob/v3.2.0/lib/rspec/core/runner.rb#L107-L113).

Due to that change, they added a `@configuration.with_suite_hooks` block that wraps up their group runner. `rspec-queue` should also use that, so it keeps compatible with other RSpec related gems, such as `rspec-rails`.

Example: `rspec-rails` [makes use of RSpec suite hooks](https://github.com/rspec/rspec-rails/blob/8c6c9590b94916199950dc8a91a9741d3be30c7c/lib/rspec/rails/active_record.rb#L11-L16) to guarantee a working `ActiveRecord` instance double, where dynamic methods are called. Documentation: https://relishapp.com/rspec/rspec-mocks/v/3-2/docs/verifying-doubles/dynamic-classes